### PR TITLE
feat(devops): Create the cycles depositor args automatically

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-	"dfx": "0.20.0",
+	"dfx": "0.23.0",
 	"canisters": {
 		"example_paid_service": {
 			"candid": "src/example/paid_service/example-paid-service.did",
@@ -26,9 +26,12 @@
 			}
 		},
 		"cycles_depositor": {
+			"dependencies": ["cycles_ledger"],
 			"type": "custom",
-			"candid": "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v1.0.1/depositor.did",
-			"wasm": "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v1.0.1/depositor.wasm.gz"
+			"build": "scripts/build.cycles_depositor.sh",
+			"init_arg_file": "out/cycles_depositor.args.did",
+			"wasm": "out/cycles_depositor.wasm.gz",
+			"candid": "out/cycles_depositor.did"
 		}
 	},
 	"defaults": {

--- a/scripts/build.cycles_depositor.args.sh
+++ b/scripts/build.cycles_depositor.args.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_help() {
+  cat <<-EOF
+	Creates the cycles_depositor installation arguments.
+
+	The file is installed at the location defined for 'cycles_depositor' in 'dfx.json'.
+	EOF
+}
+
+[[ "${1:-}" != "--help" ]] || {
+  print_help
+  exit 0
+}
+
+DFX_NETWORK="${DFX_NETWORK:-local}"
+ARG_FILE="$(jq -r .canisters.cycles_depositor.init_arg_file dfx.json)"
+
+####
+# Computes the install args, overwriting any existing args file.
+
+CANISTER_ID_CYCLES_LEDGER="${CANISTER_ID_CYCLES_LEDGER:-$(dfx canister id cycles_ledger --network "$DFX_NETWORK")}"
+
+# .. Creates the init args file
+rm -f "$ARG_FILE"
+mkdir -p "$(dirname "$ARG_FILE")"
+cat <<EOF >"$ARG_FILE"
+(record { ledger_id = principal "$CANISTER_ID_CYCLES_LEDGER" })
+EOF
+
+####
+# Success
+cat <<EOF
+SUCCESS: The cycles_depositor argument file has been created:
+cycles_depositor install args: $(sha256sum "$ARG_FILE")
+EOF

--- a/scripts/build.cycles_depositor.sh
+++ b/scripts/build.cycles_depositor.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_help() {
+  cat <<-EOF
+		Creates the cycles_depositor installation files:
+
+		- The Wasm and Candid files are downloaded.
+		- The installation args are computed based on the target network,
+		      determined by the DFX_NETWORK environment variable.
+
+		The files are installed at at the locations defined for 'cycles_depositor' in 'dfx.json'.
+	EOF
+}
+
+[[ "${1:-}" != "--help" ]] || {
+  print_help
+  exit 0
+}
+
+DFX_NETWORK="${DFX_NETWORK:-local}"
+
+LEDGER_RELEASE="v1.0.1"
+CANDID_URL="https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-${LEDGER_RELEASE}/depositor.did"
+WASM_URL="https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-${LEDGER_RELEASE}/depositor.wasm.gz"
+
+CANDID_FILE="$(jq -r .canisters.cycles_depositor.candid dfx.json)"
+WASM_FILE="$(jq -r .canisters.cycles_depositor.wasm dfx.json)"
+ARG_FILE="$(jq -r .canisters.cycles_depositor.init_arg_file dfx.json)"
+
+####
+# Downloads the candid file, if it does not exist already.
+if test -e "$CANDID_FILE"; then
+  echo "Using existing cycles_depositor candid file"
+else
+  mkdir -p "$(dirname "$CANDID_FILE")"
+  curl -sSL "$CANDID_URL" >"$CANDID_FILE"
+fi
+
+####
+# Downloads the Wasm file, if it does not exist already.
+if test -e "$WASM_FILE"; then
+  echo "Using existing cycles_depositor Wasm file"
+else
+  mkdir -p "$(dirname "$WASM_FILE")"
+  curl -sSL "$WASM_URL" >"$WASM_FILE"
+fi
+
+####
+# Computes the install args, overwriting any existing args file.
+scripts/build.cycles_depositor.args.sh
+
+# Success
+cat <<EOF
+SUCCESS: The cycles_depositor installation files have been created:
+cycles_depositor candid:       $CANDID_FILE
+cycles_depositor Wasm:         $WASM_FILE
+cycles_depositor install args: $ARG_FILE
+EOF


### PR DESCRIPTION
# Motivation
The cycles depositor needs to know the cycles ledger canister ID.  It gets it from the install arg.  Currently this is provided manually but could be provided automatically, thereby supporting `dfx deploy cycles_depositor` with no further input.

# Changes
- Generate the cycles_depositor args automatically.

# Tests
This works locally:
```
dfx deploy cycles_ledger
dfx deploy cycles_depositor
```