### PR TITLE
fix(devops): Allow spaces in conventional commit scopes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Conventional commits
         run: |
-          if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)( ?\([-a-zA-Z0-9,]+\))\!?\: ]]; then
+          if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)( ?\([-a-zA-Z0-9, ]+\))\!?\: ]]; then
               echo "PR Title passes"
           else
               echo "PR Title does not match conventions: $TITLE"


### PR DESCRIPTION
# Motivation
The scopes seem overly restrictive in not allowing spaces.

# Changes
- Allow spaces in conventional commit scopes.

# Tests
