### PR TITLE
refactor(tests): Rename the test environment

### DIFF
--- a/src/example/paid_service/tests/it/caller_pays_icrc2_cycles.rs
+++ b/src/example/paid_service/tests/it/caller_pays_icrc2_cycles.rs
@@ -1,6 +1,6 @@
 //! Tests for the `PaymentType::CallerPaysIcrc2Cycles` payment type.
 use crate::util::pic_canister::PicCanisterTrait;
-use crate::util::test_environment::{CallerPaysWithIcrc2CyclesTestSetup, PaidMethods, LEDGER_FEE};
+use crate::util::test_environment::{TestSetup, PaidMethods, LEDGER_FEE};
 use candid::Nat;
 use ic_papi_api::{PaymentError, PaymentType};
 
@@ -12,8 +12,8 @@ use ic_papi_api::{PaymentError, PaymentType};
 /// - The caller needs to pay the API cost plus one ledger fee, for the privilege of using this payment type. (See `user_approves_payment_for_paid_service(...)` in the test.)
 #[test]
 fn caller_pays_cycles_by_icrc2() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
     // Ok, now we should be able to make an API call with an ICRC-2 approve.
     let method = PaidMethods::Cost1bIcrc2Cycles;
     // Pre-approve payment
@@ -52,8 +52,8 @@ fn caller_pays_cycles_by_icrc2() {
 /// on an API method that requires the payment argument to be declared explicitly.
 #[test]
 fn caller_pays_cycles_by_named_icrc2() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
     // Ok, now we should be able to make an API call with an ICRC-2 approve.
     let method = PaidMethods::Cost1b;
     // Pre-approve payment
@@ -97,8 +97,8 @@ fn caller_pays_cycles_by_named_icrc2() {
 ///  - Note: Given that the canister consumes cycles as part of the operation, we check that the balance increases but do not check an exact amount.
 #[test]
 fn caller_pays_icrc2_cycles_works_with_large_enough_approval() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
 
     // Try calling a method with a range of approval amounts.  The call should succeed if the
     // ICRC2 approval is greater than or equal to the cost of the method.
@@ -164,8 +164,8 @@ fn caller_pays_icrc2_cycles_works_with_large_enough_approval() {
 /// Verifies that a user can pay for multiple API calls with a single approval.
 #[test]
 fn caller_pays_icrc2_cycles_supports_multiple_calls_with_a_single_approval() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
 
     // Exercise the protocol...
     // Pre-approve a large sum.
@@ -208,7 +208,7 @@ fn caller_pays_icrc2_cycles_supports_multiple_calls_with_a_single_approval() {
 /// Verifies that a user cannot pay without an ICRC2 approval.
 #[test]
 fn caller_needs_to_approve() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
+    let setup = TestSetup::default();
     // Ok, now we should be able to make an API call with an ICRC-2 approve.
     let method = PaidMethods::Cost1b;
     // Call the API
@@ -229,8 +229,8 @@ fn caller_needs_to_approve() {
 /// Verifies that an authorized ICRC2 approval cannot be used by another caller.
 #[test]
 fn payment_cannot_be_used_by_another_caller() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
     // Ok, now we should be able to make an API call with an ICRC-2 approve.
     let method = PaidMethods::Cost1b;
     // Pre-approve payment

--- a/src/example/paid_service/tests/it/caller_pays_icrc2_tokens.rs
+++ b/src/example/paid_service/tests/it/caller_pays_icrc2_tokens.rs
@@ -1,7 +1,7 @@
 //! Tests for the `PaymentType::CallerPaysIcrc2Tokens` payment type.
 use crate::util::cycles_ledger::Account;
 use crate::util::pic_canister::PicCanisterTrait;
-use crate::util::test_environment::{CallerPaysWithIcrc2CyclesTestSetup, PaidMethods, LEDGER_FEE};
+use crate::util::test_environment::{TestSetup, PaidMethods, LEDGER_FEE};
 use candid::Nat;
 use ic_papi_api::caller::CallerPaysIcrc2Tokens;
 use ic_papi_api::cycles::cycles_ledger_canister_id;
@@ -18,8 +18,8 @@ use ic_papi_api::{PaymentError, PaymentType};
 ///   - TODO: Test with other ICRC-2 ledgers as well.
 #[test]
 fn caller_pays_icrc2_tokens() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
     // Ok, now we should be able to make an API call with an ICRC-2 approve.
     let method = PaidMethods::CallerPays1bIcrc2Tokens;
     // Pre-approve payment
@@ -68,8 +68,8 @@ fn caller_pays_icrc2_tokens() {
 /// Verifies that the caller can pay for an API call with ICRC-2 tokens explicitly.
 #[test]
 fn caller_pays_icrc2_tokens_explicitly() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
     // Ok, now we should be able to make an API call with an ICRC-2 approve.
     let method = PaidMethods::Cost1b;
     // Pre-approve payment

--- a/src/example/paid_service/tests/it/patron_pays_icrc2_cycles.rs
+++ b/src/example/paid_service/tests/it/patron_pays_icrc2_cycles.rs
@@ -1,7 +1,7 @@
 //! Tests for the `PaymentType::PatronPaysIcrc2Cycles` payment type.
 use crate::util::cycles_ledger::{Account, ApproveArgs};
 use crate::util::pic_canister::PicCanisterTrait;
-use crate::util::test_environment::{CallerPaysWithIcrc2CyclesTestSetup, PaidMethods, LEDGER_FEE};
+use crate::util::test_environment::{TestSetup, PaidMethods, LEDGER_FEE};
 use candid::Nat;
 use ic_papi_api::{principal2account, PaymentError, PaymentType};
 
@@ -12,8 +12,8 @@ use ic_papi_api::{principal2account, PaymentError, PaymentType};
 /// - `user2` should be able to make the API call.
 #[test]
 fn user_pays_tokens_for_user2() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
 
     // Here the user pays for user2.
     let patron = setup.user;
@@ -105,8 +105,8 @@ fn user_pays_tokens_for_user2() {
 /// Only funded users should be able to make calls, and they should be able to make only as many calls as personally approved for them.
 #[test]
 fn user_pays_cycles_for_other_users() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
 
     // Ok, now we should be able to make an API call with EITHER an ICRC-2 approve or attached cycles, by declaring the payment type.
     // In this test, we will exercise the ICRC-2 approve.
@@ -220,7 +220,7 @@ fn user_pays_cycles_for_other_users() {
 /// If the caller can set the vendor as patron, the caller may potentially succeed in getting free goods.
 #[test]
 fn user_cannot_specify_vendor_as_patron() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
+    let setup = TestSetup::default();
 
     // Here the caller will try to specify the vendor as the patron.
     let caller = setup.user;

--- a/src/example/paid_service/tests/it/patron_pays_icrc2_tokens.rs
+++ b/src/example/paid_service/tests/it/patron_pays_icrc2_tokens.rs
@@ -1,7 +1,7 @@
 //! Tests for the `PaymentType::PatronPaysIcrc2Tokens` payment type.
 use crate::util::cycles_ledger::{Account, ApproveArgs};
 use crate::util::pic_canister::PicCanisterTrait;
-use crate::util::test_environment::{CallerPaysWithIcrc2CyclesTestSetup, PaidMethods, LEDGER_FEE};
+use crate::util::test_environment::{TestSetup, PaidMethods, LEDGER_FEE};
 use candid::Nat;
 use ic_papi_api::caller::PatronPaysIcrc2Tokens;
 use ic_papi_api::{principal2account, PaymentError, PaymentType};
@@ -13,8 +13,8 @@ use ic_papi_api::{principal2account, PaymentError, PaymentType};
 /// - `user2` should be able to make the API call.
 #[test]
 fn user_pays_tokens_for_user2() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
-    let mut expected_user_balance = CallerPaysWithIcrc2CyclesTestSetup::USER_INITIAL_BALANCE;
+    let setup = TestSetup::default();
+    let mut expected_user_balance = TestSetup::USER_INITIAL_BALANCE;
 
     // Here the user pays for user2.
     let patron = setup.user;
@@ -119,7 +119,7 @@ fn user_pays_tokens_for_user2() {
 /// If the caller can set the vendor as patron, the caller may potentially succeed in getting free goods.
 #[test]
 fn user_cannot_specify_vendor_as_patron() {
-    let setup = CallerPaysWithIcrc2CyclesTestSetup::default();
+    let setup = TestSetup::default();
 
     // Here the caller will try to specify the vendor as the patron.
     let caller = setup.user;

--- a/src/example/paid_service/tests/it/util/test_environment.rs
+++ b/src/example/paid_service/tests/it/util/test_environment.rs
@@ -36,7 +36,7 @@ impl PaidMethods {
     }
 }
 
-pub struct CallerPaysWithIcrc2CyclesTestSetup {
+pub struct TestSetup {
     /// The PocketIC instance.
     #[allow(dead_code)]
     // The Arc is used; this makes it accessible without having to refer to a specific canister.
@@ -56,7 +56,7 @@ pub struct CallerPaysWithIcrc2CyclesTestSetup {
     /// A canister used to deposit cycles into the ledger.
     pub cycles_depositor: CyclesDepositorPic,
 }
-impl Default for CallerPaysWithIcrc2CyclesTestSetup {
+impl Default for TestSetup {
     fn default() -> Self {
         let pic = Arc::new(
             PocketIcBuilder::new()
@@ -141,7 +141,7 @@ impl Default for CallerPaysWithIcrc2CyclesTestSetup {
         ans
     }
 }
-impl CallerPaysWithIcrc2CyclesTestSetup {
+impl TestSetup {
     /// The user's initial balance.
     pub const USER_INITIAL_BALANCE: u128 = 100_000_000_000;
     /// Deposit 100 * the ledger fee in the user's ledger wallet. That should be enough to be getting on with.
@@ -223,5 +223,5 @@ impl CallerPaysWithIcrc2CyclesTestSetup {
 
 #[test]
 fn icrc2_test_setup_works() {
-    let _setup = CallerPaysWithIcrc2CyclesTestSetup::default();
+    let _setup = TestSetup::default();
 }


### PR DESCRIPTION
# Motivation
The name of he test environment is misleading.

# Changes
- Rename the test environment

# Tests
Existing CI should suffice.