### PR TITLE
fix(example backend): Allow only controllers to use the demo app cycles

### DIFF
--- a/src/example/app_backend/src/lib.rs
+++ b/src/example/app_backend/src/lib.rs
@@ -1,13 +1,19 @@
 use candid::Principal;
-use ic_cdk::api::call::call_with_payment128;
+use ic_cdk::api::{call::call_with_payment128, is_controller};
 use ic_cdk_macros::{export_candid, update};
 use ic_papi_api::PaymentError;
 
 /// Calls an arbitrary method on an arbitrary canister with an arbitrary amount of cycles attached.
+///
+/// Note: This is for demonstration purposes only.  To avoid cycle theft, the API may be aclled by a controller only.
 #[update()]
 async fn call_with_attached_cycles(
     call_params: (Principal, String, u64),
 ) -> Result<String, PaymentError> {
+    assert!(
+        is_controller(&ic_cdk::caller()),
+        "The caller must be a controller."
+    );
     let (canister_id, method, cycles) = call_params;
     let arg = ();
     let (ans,): (Result<String, PaymentError>,) =


### PR DESCRIPTION
# Motivation
The example backend app has an API that allows us to demonstrate paid inter-canister calls.  This method is, however, completely unsecured and if copied into a real  world scenario, would allow anyone to drain the canister.

# Changes
- Allow only controllers to call the API

# Tests
Existing CI should still pass.