### PR TITLE
refactor(guards): Remove trait used only once

### DIFF
--- a/src/example/paid_service/src/lib.rs
+++ b/src/example/paid_service/src/lib.rs
@@ -10,7 +10,7 @@ use ic_papi_guard::guards::{
     caller_pays_icrc2_cycles::CallerPaysIcrc2CyclesPaymentGuard,
     caller_pays_icrc2_tokens::CallerPaysIcrc2TokensPaymentGuard,
 };
-use ic_papi_guard::guards::{PaymentGuard, PaymentGuard2};
+use ic_papi_guard::guards::PaymentGuard;
 use state::{set_init_args, PAYMENT_GUARD};
 
 #[init]

--- a/src/guard/src/guards/any.rs
+++ b/src/guard/src/guards/any.rs
@@ -11,7 +11,7 @@ use super::{
     caller_pays_icrc2_cycles::CallerPaysIcrc2CyclesPaymentGuard,
     caller_pays_icrc2_tokens::CallerPaysIcrc2TokensPaymentGuard,
     patron_pays_icrc2_cycles::PatronPaysIcrc2CyclesPaymentGuard,
-    patron_pays_icrc2_tokens::PatronPaysIcrc2TokensPaymentGuard, PaymentGuard, PaymentGuard2,
+    patron_pays_icrc2_tokens::PatronPaysIcrc2TokensPaymentGuard, PaymentGuard,
 };
 
 /// A guard that accepts a user-specified payment type, providing the vendor supports it.
@@ -45,8 +45,8 @@ pub enum PaymentWithConfig {
     PatronPaysIcrc2Tokens(PatronPaysIcrc2Tokens),
 }
 
-impl<const CAP: usize> PaymentGuard2 for AnyPaymentGuard<CAP> {
-    async fn deduct(&self, payment: PaymentType, fee: TokenAmount) -> Result<(), PaymentError> {
+impl<const CAP: usize> AnyPaymentGuard<CAP> {
+    pub async fn deduct(&self, payment: PaymentType, fee: TokenAmount) -> Result<(), PaymentError> {
         let payment_config = self
             .config(payment)
             .ok_or(PaymentError::UnsupportedPaymentType)?;

--- a/src/guard/src/guards/mod.rs
+++ b/src/guard/src/guards/mod.rs
@@ -1,6 +1,6 @@
 //! Guards for specific flows
 
-use ic_papi_api::{caller::TokenAmount, PaymentError, PaymentType};
+use ic_papi_api::{caller::TokenAmount, PaymentError};
 pub mod any;
 pub mod attached_cycles;
 pub mod caller_pays_icrc2_cycles;
@@ -11,9 +11,4 @@ pub mod patron_pays_icrc2_tokens;
 #[allow(async_fn_in_trait)]
 pub trait PaymentGuard {
     async fn deduct(&self, fee: TokenAmount) -> Result<(), PaymentError>;
-}
-
-#[allow(async_fn_in_trait)]
-pub trait PaymentGuard2 {
-    async fn deduct(&self, payment: PaymentType, fee: TokenAmount) -> Result<(), PaymentError>;
 }


### PR DESCRIPTION
# Motivation
The `PaymentGuard2` trait is used only once and is unlikely to be needed in future, so it can be eliminated.

# Changes
- Remove `PaymentGuard2`

# Tests
Existing CI should suffice