### PR TITLE
docs(README): Add license & contribution mode to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ dfx canister call "$MATH_CANISTER_ID" paid_is_prime '
 
 Your canister will retrieve the pre-approved payment before proceeding with the API call.
 
-## Detailed design
+## Licence & Contribution
 
-### Flow: Attached cycles
+This repository is released under the [Apache2 license](./LICENSE).
+
+Unfortunately we are unable to accept contributions yet.  When we do, we will provide a contribution guide.


### PR DESCRIPTION
# Motivation
The open sourcing policy requires declaring the license and contribution mode in the README.

# Changes
- Delete an empty section at the end of the README
- Add a section with a link to the LICENSE and declare the contribution mode.

# Tests
N/A