### PR TITLE
refactor(cycles ledger client): Add ic prefix to cycles ledger client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,16 +240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cycles-ledger-client"
-version = "0.1.0"
-dependencies = [
- "candid",
- "ic-cdk 0.16.0",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,10 +307,10 @@ name = "example_paid_service"
 version = "0.1.0"
 dependencies = [
  "candid",
- "cycles-ledger-client",
  "example-paid-service-api",
  "ic-cdk 0.16.0",
  "ic-cdk-macros 0.16.0",
+ "ic-cycles-ledger-client",
  "ic-papi-api",
  "ic-papi-guard",
  "ic-stable-structures",
@@ -628,6 +618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cycles-ledger-client"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "ic-cdk 0.16.0",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-ledger-types"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,8 +655,8 @@ name = "ic-papi-api"
 version = "0.1.0"
 dependencies = [
  "candid",
- "cycles-ledger-client",
  "hex",
+ "ic-cycles-ledger-client",
  "ic-ledger-types",
  "serde",
  "serde_bytes",
@@ -667,8 +667,8 @@ name = "ic-papi-guard"
 version = "0.1.0"
 dependencies = [
  "candid",
- "cycles-ledger-client",
  "ic-cdk 0.16.0",
+ "ic-cycles-ledger-client",
  "ic-papi-api",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ ic-papi-api = { path = "src/api" }
 ic-papi-guard = { path = "src/guard" }
 ic-stable-structures = "0.6.5"
 ic-ledger-types = "0.13.0"
-cycles-ledger-client = { path = "src/declarations/cycles_ledger" }
+ic-cycles-ledger-client = { path = "src/declarations/cycles_ledger" }
 example-paid-service-api = { path = "src/example/paid_service_api" }
 lazy_static = { version = "1.5.0" }
 hex = { version = "0.4.3" }

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 candid = { workspace = true }
-cycles-ledger-client = { workspace = true }
 hex = { workspace = true }
+ic-cycles-ledger-client = { workspace = true }
 ic-ledger-types = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/src/api/src/caller.rs
+++ b/src/api/src/caller.rs
@@ -1,6 +1,6 @@
 //! Types used primarily by the caller of the payment API.
 use candid::{CandidType, Deserialize, Principal};
-pub use cycles_ledger_client::Account;
+pub use ic_cycles_ledger_client::Account;
 
 /// How a caller states that they will pay.
 #[derive(Debug, CandidType, Deserialize, Clone, Eq, PartialEq)]

--- a/src/api/src/error.rs
+++ b/src/api/src/error.rs
@@ -1,7 +1,7 @@
 //! Payment API error types.
 use candid::{CandidType, Deserialize, Principal};
-pub use cycles_ledger_client::Account;
-use cycles_ledger_client::{TransferFromError, WithdrawFromError};
+pub use ic_cycles_ledger_client::Account;
+use ic_cycles_ledger_client::{TransferFromError, WithdrawFromError};
 
 use crate::caller::TokenAmount;
 

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-pub use cycles_ledger_client::Account;
+pub use ic_cycles_ledger_client::Account;
 use ic_ledger_types::Subaccount;
 use serde_bytes::ByteBuf;
 

--- a/src/api/src/vendor.rs
+++ b/src/api/src/vendor.rs
@@ -1,6 +1,6 @@
 //! Types used primartily by the vendor of the payment API.
 use candid::{CandidType, Deserialize, Principal};
-pub use cycles_ledger_client::Account;
+pub use ic_cycles_ledger_client::Account;
 
 use crate::caller::TokenAmount;
 

--- a/src/declarations/cycles_ledger/Cargo.toml
+++ b/src/declarations/cycles_ledger/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cycles-ledger-client"
+name = "ic-cycles-ledger-client"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/example/paid_service/Cargo.toml
+++ b/src/example/paid_service/Cargo.toml
@@ -19,5 +19,5 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 
 [dev-dependencies]
-cycles-ledger-client = { workspace = true }
+ic-cycles-ledger-client = { workspace = true }
 pocket-ic = { workspace = true }

--- a/src/example/paid_service/tests/it/caller_pays_icrc2_cycles.rs
+++ b/src/example/paid_service/tests/it/caller_pays_icrc2_cycles.rs
@@ -125,7 +125,7 @@ fn caller_pays_icrc2_cycles_works_with_large_enough_approval() {
                     response,
                     Err(PaymentError::LedgerWithdrawFromError {
                         ledger: setup.ledger.canister_id(),
-                        error: cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
+                        error: ic_cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
                             allowance: Nat::from(payment + LEDGER_FEE),
                         }
                     }),
@@ -218,7 +218,7 @@ fn caller_needs_to_approve() {
         response,
         Err(PaymentError::LedgerWithdrawFromError {
             ledger: setup.ledger.canister_id(),
-            error: cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
+            error: ic_cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
                 allowance: Nat::default(),
             }
         }),
@@ -253,7 +253,7 @@ fn payment_cannot_be_used_by_another_caller() {
             response,
             Err(PaymentError::LedgerWithdrawFromError {
                 ledger: setup.ledger.canister_id(),
-                error: cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
+                error: ic_cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
                     allowance: Nat::default(),
                 }
             }),

--- a/src/example/paid_service/tests/it/patron_pays_icrc2_cycles.rs
+++ b/src/example/paid_service/tests/it/patron_pays_icrc2_cycles.rs
@@ -56,7 +56,7 @@ fn user_pays_tokens_for_user2() {
             response,
             Err(PaymentError::LedgerWithdrawFromError {
                 ledger: setup.ledger.canister_id(),
-                error: cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
+                error: ic_cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
                     allowance: Nat::from(0u32),
                 }
             }),
@@ -150,7 +150,7 @@ fn user_pays_cycles_for_other_users() {
             response,
             Err(PaymentError::LedgerWithdrawFromError {
                 ledger: setup.ledger.canister_id(),
-                error: cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
+                error: ic_cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
                     allowance: Nat::from(0u32),
                 }
             }),
@@ -204,7 +204,7 @@ fn user_pays_cycles_for_other_users() {
             response,
             Err(PaymentError::LedgerWithdrawFromError {
                 ledger: setup.ledger.canister_id(),
-                error: cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
+                error: ic_cycles_ledger_client::WithdrawFromError::InsufficientAllowance {
                     allowance: Nat::from(0u32),
                 }
             }),

--- a/src/example/paid_service/tests/it/patron_pays_icrc2_tokens.rs
+++ b/src/example/paid_service/tests/it/patron_pays_icrc2_tokens.rs
@@ -60,7 +60,7 @@ fn user_pays_tokens_for_user2() {
             response,
             Err(PaymentError::LedgerTransferFromError {
                 ledger: setup.ledger.canister_id(),
-                error: cycles_ledger_client::TransferFromError::InsufficientAllowance {
+                error: ic_cycles_ledger_client::TransferFromError::InsufficientAllowance {
                     allowance: Nat::from(0u32),
                 }
             }),

--- a/src/guard/Cargo.toml
+++ b/src/guard/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 candid = { workspace = true }
-cycles-ledger-client = { workspace = true }
 ic-cdk = "0.16.0"
+ic-cycles-ledger-client = { workspace = true }
 ic-papi-api = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/src/guard/src/guards/caller_pays_icrc2_cycles.rs
+++ b/src/guard/src/guards/caller_pays_icrc2_cycles.rs
@@ -1,7 +1,7 @@
 //! Code to receive cycles as payment, credited to the canister, using ICRC-2 and a cycles-ledger specific withdrawal method.
 use super::{PaymentError, PaymentGuardTrait};
 use candid::Nat;
-use cycles_ledger_client::WithdrawFromArgs;
+use ic_cycles_ledger_client::WithdrawFromArgs;
 use ic_papi_api::{caller::TokenAmount, cycles::cycles_ledger_canister_id, Account};
 
 /// Accepts cycles using an ICRC-2 approve followed by withdrawing the cycles to the current canister.  Withdrawing
@@ -23,7 +23,7 @@ impl PaymentGuardTrait for CallerPaysIcrc2CyclesPaymentGuard {
         }
         // The cycles ledger has a special `withdraw_from` method, similar to `transfer_from`,
         // but that adds the cycles to the canister rather than putting it into a ledger account.
-        cycles_ledger_client::Service(cycles_ledger_canister_id())
+        ic_cycles_ledger_client::Service(cycles_ledger_canister_id())
             .withdraw_from(&WithdrawFromArgs {
                 to: own_canister_id,
                 amount: Nat::from(fee),

--- a/src/guard/src/guards/caller_pays_icrc2_tokens.rs
+++ b/src/guard/src/guards/caller_pays_icrc2_tokens.rs
@@ -5,7 +5,7 @@
 
 use super::{PaymentError, PaymentGuardTrait};
 use candid::{Nat, Principal};
-use cycles_ledger_client::TransferFromArgs;
+use ic_cycles_ledger_client::TransferFromArgs;
 use ic_papi_api::{caller::TokenAmount, Account};
 
 pub struct CallerPaysIcrc2TokensPaymentGuard {
@@ -16,7 +16,7 @@ pub struct CallerPaysIcrc2TokensPaymentGuard {
 impl PaymentGuardTrait for CallerPaysIcrc2TokensPaymentGuard {
     async fn deduct(&self, cost: TokenAmount) -> Result<(), PaymentError> {
         let caller = ic_cdk::api::caller();
-        cycles_ledger_client::Service(self.ledger)
+        ic_cycles_ledger_client::Service(self.ledger)
             .icrc_2_transfer_from(&TransferFromArgs {
                 from: Account {
                     owner: caller,

--- a/src/guard/src/guards/patron_pays_icrc2_cycles.rs
+++ b/src/guard/src/guards/patron_pays_icrc2_cycles.rs
@@ -1,7 +1,7 @@
 //! Code to receive cycles as payment, credited to the canister, using ICRC-2 and a cycles-ledger specific withdrawal method.
 use super::{PaymentError, PaymentGuardTrait};
 use candid::Nat;
-use cycles_ledger_client::WithdrawFromArgs;
+use ic_cycles_ledger_client::WithdrawFromArgs;
 use ic_papi_api::{
     caller::TokenAmount, cycles::cycles_ledger_canister_id, principal2account, Account,
 };
@@ -24,7 +24,7 @@ impl PaymentGuardTrait for PatronPaysIcrc2CyclesPaymentGuard {
         }
         // The cycles ledger has a special `withdraw_from` method, similar to `transfer_from`,
         // but that adds the cycles to the canister rather than putting it into a ledger account.
-        cycles_ledger_client::Service(cycles_ledger_canister_id())
+        ic_cycles_ledger_client::Service(cycles_ledger_canister_id())
             .withdraw_from(&WithdrawFromArgs {
                 to: own_canister_id,
                 amount: Nat::from(fee),

--- a/src/guard/src/guards/patron_pays_icrc2_tokens.rs
+++ b/src/guard/src/guards/patron_pays_icrc2_tokens.rs
@@ -1,7 +1,7 @@
 //! Code to receive cycles as payment, credited to the canister, using ICRC-2 and a cycles-ledger specific withdrawal method.
 use super::{PaymentError, PaymentGuardTrait};
 use candid::{Nat, Principal};
-use cycles_ledger_client::TransferFromArgs;
+use ic_cycles_ledger_client::TransferFromArgs;
 use ic_papi_api::{caller::TokenAmount, principal2account, Account};
 
 /// Accepts cycles using an ICRC-2 approve followed by withdrawing the cycles to the current canister.  Withdrawing
@@ -23,7 +23,7 @@ impl PaymentGuardTrait for PatronPaysIcrc2TokensPaymentGuard {
             return Err(PaymentError::InvalidPatron);
         }
         // Note: The cycles ledger client is ICRC-2 compatible so can be used here.
-        cycles_ledger_client::Service(self.ledger)
+        ic_cycles_ledger_client::Service(self.ledger)
             .icrc_2_transfer_from(&TransferFromArgs {
                 from: self.patron.clone(),
                 to: Account {


### PR DESCRIPTION
# Motivation
The cycles ledger client should have the `ic-` prefix.

# Changes
- Add the `ic-` prefix.

# Tests
Existing tests should suffice.