### PR TITLE
chore(rust): Bump Rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.80.1"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation
A new version of Rust is available.

# Changes
- Update to the latest stable Rust version.

# Tests
Existing CI should suffice