### PR TITLE
chore(devops): Update GitHub actions automagically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(github-actions): "
+      prefix-development: "chore(github-actions-dev): "
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     commit-message:
       prefix: "chore(cargo deps): "
       prefix-development: "chore(cargo deps-dev): "
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: weekly
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,10 @@ updates:
     commit-message:
       prefix: "chore(cargo deps): "
       prefix-development: "chore(cargo deps-dev): "
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     commit-message:
       prefix: "chore(github-actions): "
       prefix-development: "chore(github-actions-dev): "


### PR DESCRIPTION
# Motivation
It is desirable to specify GitHub actions by commit rather than by tag, to protect against the tag being moved.  However this makes updates tedious.  Dependabot can help wit hthis.

# Changes
- Enable dependabot updates for GitHub actions.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
