### PR TITLE
chore(devops): Update Ubuntu

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   format:
     name: 'Format'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       TITLE: ${{ github.event.pull_request.title }}
     steps:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
       - name: Have relevant files changed?
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
       - name: Have relevant files changed?
@@ -95,7 +95,7 @@ jobs:
   check-pass:
     needs: ["format", "rust-tests", "installation"]
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   integration:
     name: Integration tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pr:
     name: 'PR'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       TITLE: ${{ github.event.pull_request.title }}
     steps:
@@ -29,7 +29,7 @@ jobs:
   pr-pass:
     needs: ["pr"]
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success


### PR DESCRIPTION
# Motivation
GitHub is gradually removing Ubuntu 20.04, so it is time to move on.

# Changes
- Bump the version of Ubuntu used in GitHub runners to 24.04

# Tests
See CI