### PR TITLE
feat(devops): Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
     commit-message:
       prefix: "chore(npm deps): "
       prefix-development: "chore(npm deps-dev): "
+    groups:
+      ic-identity:
+        patterns:
+          - "@dfinity/identity"
+          - "@dfinity/auth-client"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2025-07-03
+
+### Added
+
+- Artefacts for publishing on <https://crates.io>.
+
+## [0.1.0] - 2025-01-27
+
+Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi-api"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "candid",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "example-app-backend"
+name = "example-paid-service-api"
+version = "0.1.1-alpha.1"
+dependencies = [
+ "candid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "example_app_backend"
 version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
@@ -297,7 +306,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "example-paid-service"
+name = "example_paid_service"
 version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
@@ -310,15 +319,6 @@ dependencies = [
  "ic-stable-structures",
  "lazy_static",
  "pocket-ic",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "example-paid-service-api"
-version = "0.1.1-alpha.1"
-dependencies = [
- "candid",
  "serde",
  "serde_bytes",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,16 +286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "example-paid-service-api"
-version = "0.1.1-alpha.1"
-dependencies = [
- "candid",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "example_app_backend"
+name = "example-app-backend"
 version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
@@ -306,7 +297,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "example_paid_service"
+name = "example-paid-service"
 version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
@@ -319,6 +310,15 @@ dependencies = [
  "ic-stable-structures",
  "lazy_static",
  "pocket-ic",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "example-paid-service-api"
+version = "0.1.1-alpha.1"
+dependencies = [
+ "candid",
  "serde",
  "serde_bytes",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "example-paid-service-api"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "candid",
  "serde",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "example_app_backend"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "example_paid_service"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "candid",
  "example-paid-service-api",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cycles-ledger-client"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "ic-papi-api",
  "ic-papi-guard",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi-api"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "candid",
  "hex",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi-guard"
-version = "0.0.0"
+version = "0.1.1"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "example-paid-service-api"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "candid",
  "serde",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "example_app_backend"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "example_paid_service"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "candid",
  "example-paid-service-api",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cycles-ledger-client"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ic-papi-api",
  "ic-papi-guard",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi-guard"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "example-paid-service-api"
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
  "serde",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "example_app_backend"
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "example_paid_service"
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
  "example-paid-service-api",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "ic-cycles-ledger-client"
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi"
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 dependencies = [
  "ic-papi-api",
  "ic-papi-guard",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi-api"
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
  "hex",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi-guard"
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 dependencies = [
  "candid",
  "ic-cdk 0.17.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ description = "A payment system for ICP canisters offering paid APIs."
 include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 authors = [ "Max Murphy <max@dfinity.org>" ]
 edition = "2021"
+publish = true
+version = "0.1.1"
 
 [workspace.dependencies]
 pocket-ic = "4.0.0"
@@ -24,8 +26,8 @@ ic-papi-api = { path = "src/api" }
 ic-papi-guard = { path = "src/guard" }
 ic-stable-structures = "0.6.9"
 ic-ledger-types = "0.13.0"
-ic-cycles-ledger-client = { path = "src/declarations/cycles_ledger" }
-example-paid-service-api = { path = "src/example/paid_service_api" }
+ic-cycles-ledger-client = { path = "src/declarations/cycles_ledger", version = "0.1.1" }
+example-paid-service-api = { path = "src/example/paid_service_api", version = "0.1.1" }
 lazy_static = { version = "1.5.0" }
 hex = { version = "0.4.3" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 members = ["src/api", "src/declarations/cycles_ledger", "src/example/app_backend", "src/example/paid_service", "src/example/paid_service_api", "src/guard", "src/papi"]
 resolver = "2"
-readme = "README.md"
 
 [workspace.package]
+readme = "README.md"
 repository = "https://github.com/dfinity/papi"
 license = "Apache-2.0"
 keywords = ["payment", "internet-computer", "dfinity", "canister", "api"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,17 @@
 [workspace]
 members = ["src/api", "src/declarations/cycles_ledger", "src/example/app_backend", "src/example/paid_service", "src/example/paid_service_api", "src/guard", "src/papi"]
 resolver = "2"
+readme = "README.md"
+
+[workspace.package]
+repository = "https://github.com/dfinity/papi"
+license = "Apache-2.0"
+keywords = ["payment", "internet-computer", "dfinity", "canister", "api"]
+homepage = "https://github.com/dfinity/papi"
+description = "A payment system for ICP canisters offering paid APIs."
+include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
+authors = [ "Max Murphy <max@dfinity.org>" ]
+edition = "2021"
 
 [workspace.dependencies]
 pocket-ic = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ ic-cdk = "0.17.2"
 ic-cdk-macros = "0.17.0"
 serde = "1"
 serde_bytes = "0.11"
-ic-papi-api = { path = "src/api" }
-ic-papi-guard = { path = "src/guard" }
+ic-papi-api = { path = "src/api", version = "0.1.1-alpha.1" }
+ic-papi-guard = { path = "src/guard", version = "0.1.1-alpha.1" }
 ic-stable-structures = "0.6.9"
 ic-ledger-types = "0.13.0"
 ic-cycles-ledger-client = { path = "src/declarations/cycles_ledger", version = "0.1.1-alpha.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 authors = [ "Max Murphy <max@dfinity.org>" ]
 edition = "2021"
 publish = true
-version = "0.1.1"
+version = "0.1.1-alpha.1"
 
 [workspace.dependencies]
 pocket-ic = "4.0.0"
@@ -26,8 +26,8 @@ ic-papi-api = { path = "src/api" }
 ic-papi-guard = { path = "src/guard" }
 ic-stable-structures = "0.6.9"
 ic-ledger-types = "0.13.0"
-ic-cycles-ledger-client = { path = "src/declarations/cycles_ledger", version = "0.1.1" }
-example-paid-service-api = { path = "src/example/paid_service_api", version = "0.1.1" }
+ic-cycles-ledger-client = { path = "src/declarations/cycles_ledger", version = "0.1.1-alpha.1" }
+example-paid-service-api = { path = "src/example/paid_service_api", version = "0.1.1-alpha.1" }
 lazy_static = { version = "1.5.0" }
 hex = { version = "0.4.3" }
 

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "ic-papi-api"
-version = "0.1.0"
-edition = "2021"
+license = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 candid = { workspace = true }

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -9,6 +9,8 @@ keywords = { workspace = true }
 include = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
 candid = { workspace = true }

--- a/src/declarations/cycles_ledger/Cargo.toml
+++ b/src/declarations/cycles_ledger/Cargo.toml
@@ -9,7 +9,7 @@ keywords = { workspace = true }
 include = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
-publish = false
+publish = { workspace = true }
 version = { workspace = true }
 
 [dependencies]

--- a/src/declarations/cycles_ledger/Cargo.toml
+++ b/src/declarations/cycles_ledger/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "ic-cycles-ledger-client"
-version = "0.1.0"
-edition = "2021"
+license = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 candid = { workspace = true }

--- a/src/declarations/cycles_ledger/Cargo.toml
+++ b/src/declarations/cycles_ledger/Cargo.toml
@@ -9,6 +9,8 @@ keywords = { workspace = true }
 include = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+publish = false
+version = { workspace = true }
 
 [dependencies]
 candid = { workspace = true }

--- a/src/example/app_backend/Cargo.toml
+++ b/src/example/app_backend/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "example_app_backend"
-version = "0.1.0"
-edition = "2021"
+license = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/example/app_backend/Cargo.toml
+++ b/src/example/app_backend/Cargo.toml
@@ -9,7 +9,8 @@ keywords = { workspace = true }
 include = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
-
+publish = false
+version = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/example/app_backend/Cargo.toml
+++ b/src/example/app_backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "example-app-backend"
+name = "example_app_backend"
 license = { workspace = true }
 description = { workspace = true }
 homepage = { workspace = true }

--- a/src/example/app_backend/Cargo.toml
+++ b/src/example/app_backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "example_app_backend"
+name = "example-app-backend"
 license = { workspace = true }
 description = { workspace = true }
 homepage = { workspace = true }

--- a/src/example/paid_service/Cargo.toml
+++ b/src/example/paid_service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "example-paid-service"
+name = "example_paid_service"
 license = { workspace = true }
 description = { workspace = true }
 homepage = { workspace = true }

--- a/src/example/paid_service/Cargo.toml
+++ b/src/example/paid_service/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "example_paid_service"
-version = "0.1.0"
-edition = "2021"
+license = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/example/paid_service/Cargo.toml
+++ b/src/example/paid_service/Cargo.toml
@@ -9,6 +9,8 @@ keywords = { workspace = true }
 include = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+publish = false
+version = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/example/paid_service/Cargo.toml
+++ b/src/example/paid_service/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "example_paid_service"
+name = "example-paid-service"
 license = { workspace = true }
 description = { workspace = true }
 homepage = { workspace = true }

--- a/src/example/paid_service_api/Cargo.toml
+++ b/src/example/paid_service_api/Cargo.toml
@@ -9,6 +9,8 @@ keywords = { workspace = true }
 include = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+publish = false
+version = { workspace = true }
 
 [dependencies]
 candid = { workspace = true }

--- a/src/example/paid_service_api/Cargo.toml
+++ b/src/example/paid_service_api/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "example-paid-service-api"
-version = "0.1.0"
-edition = "2021"
+license = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 candid = { workspace = true }

--- a/src/guard/Cargo.toml
+++ b/src/guard/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "ic-papi-guard"
-version = "0.1.0"
-edition = "2021"
+license = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 candid = { workspace = true }

--- a/src/guard/Cargo.toml
+++ b/src/guard/Cargo.toml
@@ -9,6 +9,8 @@ keywords = { workspace = true }
 include = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
 candid = { workspace = true }

--- a/src/papi/Cargo.toml
+++ b/src/papi/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "ic-papi"
-version = "0.1.0"
-edition = "2021"
-description = "Library for implementing Paid APIs on the Internet Computer"
+license = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 ic-papi-api = { workspace = true }

--- a/src/papi/Cargo.toml
+++ b/src/papi/Cargo.toml
@@ -9,6 +9,8 @@ keywords = { workspace = true }
 include = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
 ic-papi-api = { workspace = true }


### PR DESCRIPTION
# Motivation
Some packages need to be updated in sync, so when dependabot tries to update just one at a time, it fails.  So it is now, with the @dfinity/identity npm package update.

# Changes
- Create a group of packages that dependabot needs to update together with the npm @dfinity/identity package.

# Tests
