### PR TITLE
fix(wrapper): block forwarding to the management canister

### DIFF
--- a/src/wrapper/src/api/call.rs
+++ b/src/wrapper/src/api/call.rs
@@ -15,11 +15,12 @@ use crate::util::cycles::forward_raw;
 /// Note that not every management-canister method is controller-gated: some
 /// (e.g. `raw_rand`, threshold `sign_with_ecdsa`/`sign_with_schnorr`, the
 /// Bitcoin API) could be legitimate paid targets. Even so, the bridge is
-/// currently a target *denylist* (`target != self`), so exposing individual
-/// safe methods must not be done by unblocking the whole principal — the
-/// growing management API makes that too easy to get wrong. Instead, opt
-/// specific methods in via the `MethodConfig`/`MethodKey` allowlist in
-/// `domain::types`. Until that allowlist is wired up, block `aaaaa-aa` outright.
+/// currently a target *denylist* (it forbids only itself and `aaaaa-aa`), so
+/// exposing individual safe methods must not be done by unblocking the whole
+/// principal — the growing management API makes that too easy to get wrong.
+/// Instead, opt specific methods in via the `MethodConfig`/`MethodKey`
+/// allowlist in `domain::types`. Until that allowlist is wired up, block
+/// `aaaaa-aa` outright.
 const MANAGEMENT_CANISTER_ID: Principal = Principal::management_canister();
 
 fn map_guard_err<E: core::fmt::Debug>(e: E) -> String {

--- a/src/wrapper/src/api/call.rs
+++ b/src/wrapper/src/api/call.rs
@@ -10,7 +10,16 @@ use crate::util::cycles::forward_raw;
 ///
 /// Forwarding to it would let any caller make inter-canister calls that are
 /// authorized as *this* canister, e.g. lifecycle operations against any
-/// canister the bridge controls. It is never a legitimate bridge target.
+/// canister the bridge controls.
+///
+/// Note that not every management-canister method is controller-gated: some
+/// (e.g. `raw_rand`, threshold `sign_with_ecdsa`/`sign_with_schnorr`, the
+/// Bitcoin API) could be legitimate paid targets. Even so, the bridge is
+/// currently a target *denylist* (`target != self`), so exposing individual
+/// safe methods must not be done by unblocking the whole principal — the
+/// growing management API makes that too easy to get wrong. Instead, opt
+/// specific methods in via the `MethodConfig`/`MethodKey` allowlist in
+/// `domain::types`. Until that allowlist is wired up, block `aaaaa-aa` outright.
 const MANAGEMENT_CANISTER_ID: Principal = Principal::management_canister();
 
 fn map_guard_err<E: core::fmt::Debug>(e: E) -> String {

--- a/src/wrapper/src/api/call.rs
+++ b/src/wrapper/src/api/call.rs
@@ -1,9 +1,17 @@
+use candid::Principal;
 use ic_papi_api::PaymentType;
 
 use crate::domain::errors::BridgeError;
 use crate::domain::types::BridgeCallArgs;
 use crate::payments::guard_config::PAYMENT_GUARD;
 use crate::util::cycles::forward_raw;
+
+/// The IC management canister principal (`aaaaa-aa`).
+///
+/// Forwarding to it would let any caller make inter-canister calls that are
+/// authorized as *this* canister, e.g. lifecycle operations against any
+/// canister the bridge controls. It is never a legitimate bridge target.
+const MANAGEMENT_CANISTER_ID: Principal = Principal::management_canister();
 
 fn map_guard_err<E: core::fmt::Debug>(e: E) -> String {
     BridgeError::GuardError(format!("{e:?}")).to_string()
@@ -14,6 +22,15 @@ fn map_guard_err<E: core::fmt::Debug>(e: E) -> String {
 pub async fn bridge_call(args: BridgeCallArgs) -> Result<Vec<u8>, String> {
     if args.target == ic_cdk::api::canister_self() {
         return Err("Self-calls are not allowed through the bridge.".to_string());
+    }
+
+    // The bridge must never be usable as a proxy to the management canister:
+    // such calls would execute with the bridge's own principal as the caller.
+    if args.target == MANAGEMENT_CANISTER_ID {
+        return Err(BridgeError::ForbiddenTarget(
+            "the management canister may not be reached through the bridge.".to_string(),
+        )
+        .to_string());
     }
 
     // 1) Charge fee using the payment guard

--- a/src/wrapper/src/domain/errors.rs
+++ b/src/wrapper/src/domain/errors.rs
@@ -11,6 +11,8 @@ pub enum BridgeError {
     TargetRejected(String),
     /// Fee deduction failed (insufficient cycles/allowance/etc.).
     GuardError(String),
+    /// The requested target canister may not be reached through the bridge.
+    ForbiddenTarget(String),
 }
 
 impl fmt::Display for BridgeError {
@@ -19,6 +21,7 @@ impl fmt::Display for BridgeError {
             BridgeError::Candid(e) => write!(f, "Candid error: {e}"),
             BridgeError::TargetRejected(e) => write!(f, "Target canister rejected call: {e}"),
             BridgeError::GuardError(e) => write!(f, "Payment guard error: {e}"),
+            BridgeError::ForbiddenTarget(e) => write!(f, "Forbidden target: {e}"),
         }
     }
 }

--- a/src/wrapper/tests/it/bridge_tests.rs
+++ b/src/wrapper/tests/it/bridge_tests.rs
@@ -23,6 +23,24 @@ fn bridge_call_fails_if_target_is_self() {
 }
 
 #[test]
+fn bridge_call_fails_if_target_is_management_canister() {
+    let setup = TestSetup::default();
+    let args = Call0Args {
+        target: Principal::management_canister(),
+        method: "update_settings".to_string(),
+        fee_amount: 0,
+        payment: Some(PaymentType::AttachedCycles),
+        cycles_to_forward: None,
+    };
+
+    let result: Result<Result<Vec<u8>, String>, String> =
+        setup.wrapper.update(setup.user, "call0", args);
+    let inner_result = result.expect("Failed to reach canister");
+    let err = inner_result.expect_err("Should have returned an error");
+    assert!(err.contains("the management canister may not be reached through the bridge."));
+}
+
+#[test]
 fn bridge_call_fails_if_insufficient_cycles() {
     let setup = TestSetup::default();
     let args = Call0Args {


### PR DESCRIPTION
## Summary

The bridge's `bridge_call` only rejected calls whose `target` was the canister itself:

```rust
if args.target == ic_cdk::api::canister_self() {
    return Err("Self-calls are not allowed through the bridge.".to_string());
}
```

It did **not** block the IC management canister (`aaaaa-aa`). Because `call0`/`call_blob` are public `#[update]` entrypoints that forward an arbitrary `target`/`method`/raw args, any caller could set `target = aaaaa-aa` and have the bridge forward a management-canister call (`update_settings`, `install_code`, `uninstall_code`, `stop_canister`, …).

On the IC, an inter-canister call is authorized as the **calling canister's** principal, and management-canister methods authorize on whether the caller is a *controller* of the `canister_id` in the payload. So a forwarded management call executes with the bridge's own authority — if the bridge is (or becomes) a controller of any canister, an attacker could change controllers, uninstall code, or stop that canister.

## Fix

Reject the management canister principal explicitly, alongside the existing self-call guard, via a new `BridgeError::ForbiddenTarget` variant.

## Notes on severity

This is primarily a hardening / defense-in-depth fix. The concrete impact is contingent on the bridge controlling some canister; under a default deployment where the bridge controls nothing, the management canister would reject the forwarded call anyway. Blocking `aaaaa-aa` at the bridge closes the gap regardless of controller configuration. A longer-term improvement would be moving from a target denylist to an allowlist of permitted `(target, method)` pairs (the `MethodKey`/`MethodConfig` types already anticipate this).

## Testing

- `cargo build` / `cargo clippy -p ic-papi-wrapper` — clean
- New integration test `bridge_call_fails_if_target_is_management_canister` passes alongside the existing bridge tests (3 passed).